### PR TITLE
doc and maven dependency refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ that the `wss` (WebSocket Secure) protocol is used, this is enforced by
 the Relay server when registering workflows. See the
 [Guide](https://developer.relaypro.com/docs/requirements) on this topic.
 
+The [Eclipse Jetty](https://www.eclipse.org/jetty/) module used for an http server here does support TLS. See
+the [Jetty instructions](https://www.eclipse.org/jetty/documentation/jetty-11/operations-guide/index.html#og-keystore)
+on configuring TLS.
+
 ## Verbose Mode Logging
 
 The SDK is using slf4j and the sample apps are providing a binding to log4j, so

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.0'
-    implementation group: 'org.slf4j', name: 'slf4j-log4j12', version: '2.0.0'
+    implementation group: 'org.slf4j', name: 'slf4j-reload4j', version: '2.0.0'
 
     implementation 'com.google.guava:guava:30.1.1-jre'
     implementation group: 'jakarta.websocket', name: 'jakarta.websocket-api', version: '2.0.0'


### PR DESCRIPTION
- Use slf4j-reload4j instead of slf4j-log4j12 due to vulnerabilities.
- Mention TLS config for Jetty.