### PR TITLE
Added convertTargetObjects method, and changed API target param type to Object

### DIFF
--- a/sdk/src/main/java/com/relaypro/sdk/RelayUtils.java
+++ b/sdk/src/main/java/com/relaypro/sdk/RelayUtils.java
@@ -65,9 +65,9 @@ class RelayUtils {
     }
 
     @SafeVarargs
-    static Map<String, Object> buildRequest(RequestType type, String sourceUri, Map.Entry<String, Object> ...params) {
+    static Map<String, Object> buildRequest(RequestType type, Map<String, Object> target, Map.Entry<String, Object> ...params) {
         Map<String, Object> map = buildRequest(type, params);
-        map.put("_target", RelayUtils.makeTarget(sourceUri));
+        map.put("_target", target);
         return map;
     }
 


### PR DESCRIPTION
We don't have to actually merge this in, but I wanted to go ahead and try out the implementation of passing in any type (StartEvent, Trigger, etc.) into startInteraction or any API and have the convertTargetObject() method convert the generic type that was passed in to it that to the target map/dictionary like you did in Python in Java.  So far, this works with the HelloWorld sample, but I haven't tested it yet with the other samples to make sure nothing broke, since this would be kind of a big change.