### PR TITLE
Added missing interaction lifecycle methods

### DIFF
--- a/sdk/src/main/java/com/relaypro/sdk/types/InteractionLifecycleEvent.java
+++ b/sdk/src/main/java/com/relaypro/sdk/types/InteractionLifecycleEvent.java
@@ -45,4 +45,20 @@ public class InteractionLifecycleEvent {
     public boolean isTypeEnded() {
         return "ended".equals(this.type);
     }
+
+    /**
+     * Returns whether the InteractionLifecycleEvent has a type of "resumed".
+     * @return true if the type is "resumed", false otherwise.
+     */
+    public boolean isTypeResumed() {
+        return "resumed".equals(this.type);
+    }
+
+    /**
+     * Returns whether the InteractionLifecycleEvent has a type of "suspended".
+     * @return true if the type is "suspended", false otherwise.
+     */
+    public boolean isTypeSuspended() {
+        return "suspended".equals(this.type);
+    }
 }


### PR DESCRIPTION
While filling in a missing Java sample in the Targeting Devices section in the guides, I noticed that the Java SDK is missing the methods it needs for isTypeResumed() and isTypeSuspended(), so I went ahead and added these in.